### PR TITLE
Fix xss vulnerability

### DIFF
--- a/jshare.js
+++ b/jshare.js
@@ -1,4 +1,5 @@
 var _ = require("underscore");
+var serialize = require("serialize-javascript");
 
 module.exports = function(namespace) {
 	return function(req, res, next) {
@@ -77,7 +78,7 @@ function getOutputJS(outputScriptTag, namespace, obj) {
 	}
 
 	output += jshareMergeObject.toString();
-	output += 'window.' + namespace + '=' + 'jshareMergeObject(window.' + namespace + ', ' + JSON.stringify(obj) + ');';
+	output += 'window.' + namespace + '=' + 'jshareMergeObject(window.' + namespace + ', ' + serialize(obj, {isJSON: true}) + ');';
 	
 	if(outputScriptTag === true) {
 		output += '</script>';

--- a/package.json
+++ b/package.json
@@ -1,17 +1,21 @@
 {
-    "name": "jshare"
-  , "description" : "Share you server side Node.js/Express variables with your client side Javascript."	
-  , "version": "0.0.9"
-  , "dependencies": {
+  "name": "jshare",
+  "description": "Share you server side Node.js/Express variables with your client side Javascript.",
+  "version": "0.0.9",
+  "dependencies": {
+    "serialize-javascript": "^1.3.0",
     "underscore": "*"
-    },
-   "devDependencies": {
-        "mocha": "*"
-      , "expect.js": "*"
-    }
-  , "author" : "Alex Friedman"
-  , "repository" :
-  { "type" : "git"
-  , "url" : "https://github.com/brooklynDev/JShare"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "devDependencies": {
+    "mocha": "*",
+    "expect.js": "*"
+  },
+  "author": "Alex Friedman",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/brooklynDev/JShare"
   }
 }

--- a/test/jshare.js
+++ b/test/jshare.js
@@ -38,7 +38,7 @@ describe('jshare', function() {
 		})
 	})
 
-	it('should not contain script tag in the ', function() {
+	it('should not contain script tag in the resulting payload', function() {
 		runJShareTest('jshare', { value: "</script><script>alert('xss')</script>" }, { outputScriptTag: false }, function(req, res, result) {
 			expect(result.indexOf('</script><script>')).to.eql(-1);
 		})

--- a/test/jshare.js
+++ b/test/jshare.js
@@ -38,6 +38,12 @@ describe('jshare', function() {
 		})
 	})
 
+	it('should not contain script tag in the ', function() {
+		runJShareTest('jshare', { value: "</script><script>alert('xss')</script>" }, { outputScriptTag: false }, function(req, res, result) {
+			expect(result.indexOf('</script><script>')).to.eql(-1);
+		})
+	})
+
 	it('should contain a reference to external script', function() {
 		runJShareTest('jshare', { value: 100 }, { useExternalJSFile:true }, function(req, res, result) {
 			expect(result).to.be.contain("<script type='text/javascript' src='/jshare.js");


### PR DESCRIPTION
As explained in [this blog post](https://medium.com/node-security/the-most-common-xss-vulnerability-in-react-js-applications-2bdffbcc1fa0#.6j9jxc5ni), using `JSON.stringify` to serialize data that will be sent directly to the client will not escape html entities properly, thus exposing your site to XSS attacks.
This PR replaces the `JSON.stringify` call to use the [Serialize Javascript](https://github.com/yahoo/serialize-javascript) library from Yahoo, which will properly escape the resulting string.